### PR TITLE
Changed time limit to stop processing msgs and loop around

### DIFF
--- a/lib/ruote/worker.rb
+++ b/lib/ruote/worker.rb
@@ -187,7 +187,7 @@ module Ruote
       now = Time.now.utc
       delta = now - @last_time
 
-      return if delta < 0.8
+      return if delta < 10.0 # changed by RSM from 0.8  2017-02-07
         #
         # consider schedules at most twice per second (don't do that job
         # too often)
@@ -220,7 +220,7 @@ module Ruote
           collisions = 0
         end
 
-        break if Time.now.utc - @last_time >= 0.8
+        break if Time.now.utc - @last_time >= 10.0
       end
     end
 
@@ -699,4 +699,3 @@ module Ruote
     end
   end
 end
-


### PR DESCRIPTION
### Base branch(merging into)

release/5.1.0.waterfield

### Pivotal story link

[139221907](https://www.pivotaltracker.com/story/show/139221907)

### What was the enhancement or issue?

Workflow worker not running messages.

1. Timeout of 0.8 seconds in Ruote::Worker to stop processing and go
   back to check on schedules is too small for us. It leads to too
   much overhead restarting the processing loop. Change it to 10
   seconds. We do not use scheduling.

2. There is no primary key index on ruote_wf_documents. This
   seems to be a seeding issue.

### Resolution?

- [X] Change our fork of Ruote to change the timeout of 0.8 to 10.0
- [X] Change load_seed.thor to remove ruote_wf_documents so that the gem can create it properly
- [X] Add a migration to fix any databases that are missing the primary key

**Missing Index**

`ALTER TABLE ruote_wf_documents ADD CONSTRAINT pk__ruote_wf PRIMARY KEY CLUSTERED (typ, ide, rev);`

### How did you verify the modification?

Tested impact on 192.168.14.89 with special logging.
Tested migration scenarios by hand.

### Changes to deployments (new settings)?


### Screenshots


### Delete Branch after Merge?

yes
